### PR TITLE
Improve logic to gather words

### DIFF
--- a/denops/ddc/sources/around.ts
+++ b/denops/ddc/sources/around.ts
@@ -10,7 +10,7 @@ import {
 
 function allWords(lines: string[]): string[] {
   const words = lines
-    .flatMap((line) => [...line.matchAll(/[a-zA-Z0-9_]+/g)])
+    .flatMap((line) => [...line.matchAll(/[\p{L}\d]+/gu)])
     .map((match) => match[0]);
   return Array.from(new Set(words)); // remove duplication
 }

--- a/denops/ddc/sources/around.ts
+++ b/denops/ddc/sources/around.ts
@@ -9,8 +9,10 @@ import {
 } from "https://deno.land/x/ddc_vim@v0.3.0/deps.ts#^";
 
 function allWords(lines: string[]): string[] {
-  return lines.flatMap((line) => [...line.matchAll(/[a-zA-Z0-9_]+/g)])
-    .map((match) => match[0]).filter((e, i, self) => self.indexOf(e) === i);
+  const words = lines
+    .flatMap((line) => [...line.matchAll(/[a-zA-Z0-9_]+/g)])
+    .map((match) => match[0]);
+  return Array.from(new Set(words)); // remove duplication
 }
 
 type Params = {


### PR DESCRIPTION
1. Reduce computational complexity
   - See [JavaScriptで重複排除を自分で実装してはいけない（Setを使う） - Qiita](https://qiita.com/netebakari/items/7c1db0b0cea14a3d4419)
2. Fix regexp to hit `café`